### PR TITLE
Open styles folder by default when adding styles

### DIFF
--- a/src/ipe/lua/actions.lua
+++ b/src/ipe/lua/actions.lua
@@ -2590,7 +2590,7 @@ local function sheets_add(d, dd)
   local i = d:get("list")
   if not i then i = 1 end
   local s, f = ipeui.fileDialog(dd.model.ui:win(), "open", "Add stylesheet",
-				filter_stylesheets)
+				filter_stylesheets, config.styleDirs[1])
   if not s then return end
   local sheet, msg = ipe.Sheet(s)
   if not sheet then


### PR DESCRIPTION
I currently have to create a paper version (serif font) and a presentation version (sans-serif) of several figures. To be more flexible and to avoid having to copy over the "Document properties"->"LaTeX Preamble" to every file, I created a style. However, adding the style to every file requires quite a lot of clicks because I need to navigate to the styles folder again.

Currently, the "Add style" file picker uses the current working dir, which in most cases probably is the directory of the current ipe file.

This PR sets the default folder of the file picker to the global styles folder (`~/.ipe/styles`). That way, the picker immediately shows the list of all available styles to choose from.