### PR TITLE
do not create text object with empty spaces only

### DIFF
--- a/src/ipe/lua/tools.lua
+++ b/src/ipe/lua/tools.lua
@@ -950,6 +950,10 @@ function MODEL:createText(mode, pos, width, pinned)
   if ((prefs.auto_external_editor and prefs.editor_closes_dialog)
     or d:execute(prefs.editor_size)) then
     local t = d:get("text")
+    if t:match("^%s*$") ~= nil then
+      -- do not create Text containing only white space
+      return
+    end
     local style = styles[d:get("style")]
     local size = sizes[d:get("size")]
     local obj = ipe.Text(self.attributes, t, pos, width)

--- a/src/ipe/lua/tools.lua
+++ b/src/ipe/lua/tools.lua
@@ -950,8 +950,7 @@ function MODEL:createText(mode, pos, width, pinned)
   if ((prefs.auto_external_editor and prefs.editor_closes_dialog)
     or d:execute(prefs.editor_size)) then
     local t = d:get("text")
-    if t:match("^%s*$") ~= nil then
-      -- do not create Text containing only white space
+    if t:match("^%s*$") then
       return
     end
     local style = styles[d:get("style")]


### PR DESCRIPTION
When adding Text label, sometimes the editor exits with only white space or even no text at all. In these cases, do not create an empty label object. Instead, just return. 