### PR TITLE
support externally linked (instead of embedded) images

### DIFF
--- a/src/include/ipebase.h
+++ b/src/include/ipebase.h
@@ -391,6 +391,8 @@ public:
     static void initLib(int version);
     static void setDebug(bool debug);
     static String currentDirectory();
+    static void changeDirectory(String dir);
+    static String parentDirectory(String dir);
     static String latexPath();
     static bool fileExists(String fname);
     static bool listDirectory(String path, std::vector<String> & files);

--- a/src/include/ipebitmap.h
+++ b/src/include/ipebitmap.h
@@ -76,6 +76,9 @@ public:
     inline bool hasAlpha() const;
     inline int colorKey() const;
 
+    inline void setExternalPath(String path);
+    void changeExternalPathRelativeBase(String new_base);
+
     Buffer pixelData();
 
     inline int objNum() const;
@@ -151,6 +154,13 @@ inline bool Bitmap::isExternal() const { return (iImp->iFlags & EExternal) != 0;
 
 //! The path to the external bitmap file
 inline String Bitmap::externalPath() const { return iImp->iPath; }
+
+//! Set the path to the external bitmap file
+inline void Bitmap::setExternalPath(String path) {
+    assert(isExternal());
+    assert(!path.empty());
+    iImp->iPath = path;
+}
 
 //! Does the bitmap have transparency?
 /*! Bitmaps with color key will return false here. */

--- a/src/include/ipebitmap.h
+++ b/src/include/ipebitmap.h
@@ -63,6 +63,7 @@ public:
     void saveAsXml(Stream & stream, int id, int pdfObjNum = -1) const;
 
     inline bool isNull() const;
+    inline bool isLoaded() const;
     bool equal(Bitmap rhs) const;
 
     inline int width() const;
@@ -127,6 +128,11 @@ private:
 
 //! Is this a null bitmap?
 inline bool Bitmap::isNull() const { return (iImp == nullptr); }
+
+//! Could the pixel data for this bitmap be loaded?
+inline bool Bitmap::isLoaded() const {
+    return !isNull() && (iImp->iData.size() > 0 || iImp->iPixelData.size() > 0);
+}
 
 //! Return width of pixel array.
 inline int Bitmap::width() const { return iImp->iWidth; }

--- a/src/ipelib/ipebitmap.cpp
+++ b/src/ipelib/ipebitmap.cpp
@@ -30,6 +30,8 @@
 
 #include "ipebitmap.h"
 #include "ipeutils.h"
+
+#include <filesystem>
 #include <zlib.h>
 
 using namespace ipe;
@@ -745,6 +747,13 @@ Bitmap Bitmap::readExternal(String pathAttr, const XmlAttributes & attr,
 	eret.iImp->iFlags = Bitmap::EExternal;
 	return eret;
     }
+}
+
+void Bitmap::changeExternalPathRelativeBase(String new_base) {
+    new_base = Platform::realPath(new_base);
+    String old_path = Platform::realPath(externalPath());
+    setExternalPath(
+	std::filesystem::proximate(old_path.s(), new_base.s()).generic_string());
 }
 
 // --------------------------------------------------------------------

--- a/src/ipelib/ipebitmap_win.cpp
+++ b/src/ipelib/ipebitmap_win.cpp
@@ -87,19 +87,20 @@ bool dctDecode(Buffer dctData, Buffer pixelData) {
 // --------------------------------------------------------------------
 // The graphics file formats supported by GDI+ are
 // BMP, GIF, JPEG, PNG, TIFF.
-Bitmap Bitmap::readPNG(const char * fname, Vector & dotsPerInch, const char *& errmsg) {
+const char * Bitmap::readPNGInfo(const char * fname, int & w, int & h, uint32_t & flags,
+				 Buffer & pixels, Vector & dotsPerInch) {
     // load without color correction
     Gdiplus::Bitmap * bitmap = Gdiplus::Bitmap::FromFile(String(fname).w().data(), FALSE);
     if (bitmap->GetLastStatus() != Gdiplus::Ok) {
 	delete bitmap;
-	return Bitmap();
+	return "GDI+ Status not OK";
     }
 
     dotsPerInch =
 	Vector(bitmap->GetHorizontalResolution(), bitmap->GetVerticalResolution());
-
-    int w = bitmap->GetWidth();
-    int h = bitmap->GetHeight();
+    w = bitmap->GetWidth();
+    h = bitmap->GetHeight();
+    flags = Bitmap::ENative;
 
     Buffer pixelData(4 * w * h);
     Gdiplus::BitmapData * bitmapData = new Gdiplus::BitmapData;
@@ -114,13 +115,13 @@ Bitmap Bitmap::readPNG(const char * fname, Vector & dotsPerInch, const char *& e
 		     Gdiplus::ImageLockModeRead | Gdiplus::ImageLockModeUserInputBuf,
 		     PixelFormat32bppARGB, bitmapData);
 
-    Bitmap bm(w, h, Bitmap::ENative, pixelData);
+    // TODO check whether we need to do the processing of analyze() here
 
     bitmap->UnlockBits(bitmapData);
     delete bitmapData;
     delete bitmap;
 
-    return bm;
+    return nullptr;
 }
 
 // --------------------------------------------------------------------

--- a/src/ipelib/ipedoc.cpp
+++ b/src/ipelib/ipedoc.cpp
@@ -297,6 +297,14 @@ bool Document::save(TellStream & stream, FileFormat format, uint32_t flags) cons
 bool Document::save(const char * fname, FileFormat format, uint32_t flags) const {
     std::FILE * fd = Platform::fopen(fname, "wb");
     if (!fd) return false;
+
+    String new_base = Platform::parentDirectory(Platform::realPath(fname));
+    BitmapFinder bmf;
+    findBitmaps(bmf);
+    for (auto & bm : bmf.iBitmaps) {
+	if (bm.isExternal()) bm.changeExternalPathRelativeBase(new_base);
+    }
+
     FileStream stream(fd);
     bool result = save(stream, format, flags);
     std::fclose(fd);

--- a/src/ipelib/ipedoc.cpp
+++ b/src/ipelib/ipedoc.cpp
@@ -217,6 +217,7 @@ Document * Document::load(const char * fname, int & reason) {
     reason = EFileOpenError;
     std::FILE * fd = Platform::fopen(fname, "rb");
     if (!fd) return nullptr;
+    Platform::changeDirectory(Platform::parentDirectory(fname));
     FileSource source(fd);
     FileFormat format = fileFormat(source);
     std::rewind(fd);

--- a/src/ipelib/ipeiml.cpp
+++ b/src/ipelib/ipeiml.cpp
@@ -159,30 +159,20 @@ bool ImlParser::parseBitmap() {
     XmlAttributes att;
     if (!parseAttributes(att)) return false;
     String objRefStr;
-    // only load the pdfObject data if the XML contains no base64 data / external path
-    if (att.slash()) {
-	if (att.has("pdfObject", objRefStr)) {
-	    Lex lex(objRefStr);
-	    Buffer data = pdfStream(lex.getInt());
-	    Buffer alpha;
-	    lex.skipWhitespace();
-	    if (!lex.eos()) alpha = pdfStream(lex.getInt());
-	    Bitmap bitmap(att, data, alpha);
-	    iBitmaps.push_back(bitmap);
-	} else if (att.has("path", objRefStr)) {
-	    const char * errmsg = nullptr;
-	    Bitmap bitmap = Bitmap::readExternal(objRefStr, att, errmsg);
-	    if (!errmsg) {
-		iBitmaps.push_back(bitmap);
-	    } else {
-		return false;
-	    }
-	} else {
-	    return false;
-	}
+    if (att.has("path", objRefStr)) {
+	const char * errmsg = nullptr;
+	iBitmaps.push_back(Bitmap::readExternal(objRefStr, att, errmsg));
+    } else if (att.has("pdfObject", objRefStr)) {
+	Lex lex(objRefStr);
+	Buffer data = pdfStream(lex.getInt());
+	Buffer alpha;
+	lex.skipWhitespace();
+	if (!lex.eos()) alpha = pdfStream(lex.getInt());
+	Bitmap bitmap(att, data, alpha);
+	iBitmaps.push_back(bitmap);
     } else {
 	String bits;
-	if (!parsePCDATA("bitmap", bits)) return false;
+	if (att.slash() || !parsePCDATA("bitmap", bits)) return false;
 	Bitmap bitmap(att, bits);
 	iBitmaps.push_back(bitmap);
     }

--- a/src/ipelib/ipepainter.cpp
+++ b/src/ipelib/ipepainter.cpp
@@ -233,7 +233,35 @@ void Painter::drawPath(TPathMode mode) {
 */
 void Painter::drawBitmap(Bitmap bitmap) {
     assert(!iInPath);
-    doDrawBitmap(bitmap);
+    assert(!bitmap.isNull());
+    if (!bitmap.isLoaded()) {
+	push();
+	// setState(State()); // reset state
+	setOpacity(Attribute(Fixed(1000)));
+	setStrokeOpacity(Attribute(Fixed(1000)));
+	setFill(Attribute(Color(1000, 1000, 1000)));
+	setStroke(Attribute(Color(1000, 0, 0)));
+	setLineJoin(EMiterJoin);
+	setTiling(Attribute::normal(ETiling));
+	setGradient(Attribute::normal(EGradient));
+
+	setPen(Attribute(Fixed(2)));
+	newPath();
+	rect(Rect{Vector{0, 0}, Vector{1, 1}});
+	drawPath(EStrokedAndFilled);
+
+	setPen(Attribute(Fixed(1)));
+	newPath();
+	moveTo(Vector{0, 0});
+	lineTo(Vector{1, 1});
+	moveTo(Vector{1, 0});
+	lineTo(Vector{0, 1});
+	drawPath(EStrokedOnly);
+
+	pop();
+    } else {
+	doDrawBitmap(bitmap);
+    }
 }
 
 //! Render a text object.

--- a/src/ipelib/ipepdfwriter.cpp
+++ b/src/ipelib/ipepdfwriter.cpp
@@ -562,7 +562,7 @@ void PdfWriter::createStream(const char * data, int size, bool preCompressed) {
 
 void PdfWriter::embedBitmap(Bitmap bitmap) {
     int smaskNum = -1;
-    auto embed = bitmap.embed();
+    auto embed = bitmap.getEmbedData();
     if (bitmap.hasAlpha() && embed.second.size() > 0) {
 	smaskNum = startObject();
 	iStream << "<<\n";

--- a/src/ipelib/ipepdfwriter.cpp
+++ b/src/ipelib/ipepdfwriter.cpp
@@ -610,6 +610,7 @@ void PdfWriter::embedBitmap(Bitmap bitmap) {
 
 void PdfWriter::embedBitmaps(const BitmapFinder & bm) {
     for (BmIter it = bm.iBitmaps.begin(); it != bm.iBitmaps.end(); ++it) {
+	if (!it->isLoaded()) continue;
 	BmIter it1 = std::find(iBitmaps.begin(), iBitmaps.end(), *it);
 	if (it1 == iBitmaps.end()) {
 	    // look again, more carefully

--- a/src/ipelib/ipeplatform.cpp
+++ b/src/ipelib/ipeplatform.cpp
@@ -30,6 +30,7 @@
 
 #include "ipeattributes.h"
 #include "ipebase.h"
+#include <filesystem>
 
 #ifdef WIN32
 #define NTDDI_VERSION 0x06000000
@@ -400,17 +401,18 @@ void ipeDebugBuffer(Buffer data, int maxsize) {
 // --------------------------------------------------------------------
 
 //! Returns current working directory.
-/*! Returns empty string if something fails. */
 String Platform::currentDirectory() {
-#ifdef WIN32
-    wchar_t * buffer = _wgetcwd(nullptr, 0);
-    return String(buffer);
-#else
-    char buffer[PATH_MAX];
-    buffer[0] = 0;
-    if (getcwd(buffer, PATH_MAX) != buffer) return String();
-    return String(buffer);
-#endif
+    return std::filesystem::current_path().generic_string();
+}
+
+//! Changes the current working directory.
+void Platform::changeDirectory(String dir) {
+    if (!dir.empty()) std::filesystem::current_path(dir.z());
+}
+
+//! Get the directory containg the given file.
+String Platform::parentDirectory(String file) {
+    return std::filesystem::path(file.z()).parent_path().generic_string();
 }
 
 //! Returns drive on which Ipe executable exists.

--- a/src/ipelib/ipeplatform.cpp
+++ b/src/ipelib/ipeplatform.cpp
@@ -406,8 +406,9 @@ String Platform::currentDirectory() {
     wchar_t * buffer = _wgetcwd(nullptr, 0);
     return String(buffer);
 #else
-    char buffer[1024];
-    if (getcwd(buffer, 1024) != buffer) return String();
+    char buffer[PATH_MAX];
+    buffer[0] = 0;
+    if (getcwd(buffer, PATH_MAX) != buffer) return String();
     return String(buffer);
 #endif
 }
@@ -456,6 +457,7 @@ String Platform::realPath(String fname) {
     return String(wresult);
 #else
     char rpath[PATH_MAX];
+    rpath[0] = 0;
     if (realpath(fname.z(), rpath)) return String(rpath);
     if (errno != ENOENT || fname.left(1) == "/") return fname; // not much we can do
     if (realpath(".", rpath) == nullptr) return fname;         // nothing we can do

--- a/src/ipelua/ipeluaobj.cpp
+++ b/src/ipelua/ipeluaobj.cpp
@@ -854,6 +854,14 @@ static int object_info(lua_State * L) {
     }
     push_string(L, format);
     lua_setfield(L, -2, "format");
+    lua_pushboolean(L, bm.isExternal());
+    lua_setfield(L, -2, "external");
+    lua_pushboolean(L, bm.isLoaded());
+    lua_setfield(L, -2, "loaded");
+    if (bm.isExternal()) {
+	push_string(L, bm.externalPath());
+	lua_setfield(L, -2, "path");
+    }
     return 1;
 }
 


### PR DESCRIPTION
This is a first step towards external image support, see also #545.
I think we can copy most of the UX here from the inkscape SVG editor, which already has a very similar functionality:
- https://inkscape-manuals.readthedocs.io/en/latest/import-pictures.html
- https://wiki.inkscape.org/wiki/Image_properties_dialog_enhancements
- https://wiki.inkscape.org/wiki/Linked_bitmap_manager
- https://wiki.inkscape.org/wiki/Image_links_manager

ToDo:
- [x] read image data from external file instead of base64 data in XML when encoding is "externalPath"
- [x] check that paths are always resolved relatively to ipe file (which is not necessarily the cwd?)
- [ ] do not change cwd, but store a per-document relative base path instead
- [x] use path info instead of image data when writing XML (may need special treatment for PDF)
- [x] update paths when saving in a different directory
- [x] use replacement image buffer when image could not be loaded
- [ ] reload external images when running latex (or only do so if their timestamps changed)
- [ ] check handling of links when autosaving to different (central) directory 
- [ ] UI: allow user to choose between embedding and (relative/absolute) linking when inserting images
- [ ] UI: allow converting present images between embedded and linked in right-click context menu
- [ ] UI: find way of handling / resolving external images that cannot be loaded (e.g. search again with a base path different from current working dir, allow giving absolute paths to replacements,...)
- [ ] UI: ask whether we should use embedded image data when path from just-loaded PDF cannot be resolved (same for reloading external images that suddenly no longer exist)
- [ ] allow "temporarily" storing image data externally for quicker autosaving and on ipe-web