### PR TITLE
Enable control point snapping for circular arc midpoints

### DIFF
--- a/src/include/ipegeo.h
+++ b/src/include/ipegeo.h
@@ -332,6 +332,7 @@ public:
     Rect bbox() const;
     inline Vector beginp() const;
     inline Vector endp() const;
+    Vector midpoint() const;
 
     void intersect(const Line & l, std::vector<Vector> & result) const;
     void intersect(const Segment & s, std::vector<Vector> & result) const;

--- a/src/ipelib/ipegeo.cpp
+++ b/src/ipelib/ipegeo.cpp
@@ -844,6 +844,27 @@ Rect Bezier::bbox() const {
     return Rect(box.bottomLeft() - Vector(0.5, 0.5), box.topRight() + Vector(0.5, 0.5));
 }
 
+Vector Arc::midpoint() const {
+    // Normalize iBeta with respect to iAlpha to handle cases where iAlpha > iBeta
+    Angle betaNorm = iBeta;
+    betaNorm.normalize(iAlpha);
+    double delta = betaNorm - iAlpha;
+
+    if (sq(delta - IpeTwoPi) < 1e-20) {
+	// Full ellipse
+	Angle midAngle(iAlpha + IpePi);
+	return iM * Vector(midAngle);
+    }
+
+    if (sq(delta) < 1e-20) {
+	// Zero-length arc, return the starting point
+	return iM * Vector(iAlpha);
+    }
+
+    Angle midAngle(iAlpha + delta / 2);
+    return iM * Vector(midAngle);
+}
+
 //! Find (approximately) nearest point on Bezier spline.
 /*! Find point on spline nearest to \a v, but only if
   it is closer than \a bound.

--- a/src/ipelib/ipegeo.cpp
+++ b/src/ipelib/ipegeo.cpp
@@ -845,24 +845,20 @@ Rect Bezier::bbox() const {
 }
 
 Vector Arc::midpoint() const {
-    // Normalize iBeta with respect to iAlpha to handle cases where iAlpha > iBeta
-    Angle betaNorm = iBeta;
-    betaNorm.normalize(iAlpha);
-    double delta = betaNorm - iAlpha;
-
-    if (sq(delta - IpeTwoPi) < 1e-20) {
-	// Full ellipse
-	Angle midAngle(iAlpha + IpePi);
-	return iM * Vector(midAngle);
+    if ((iBeta - iAlpha > IpeTwoPi - 1e-10)
+	|| (iAlpha - 1e-10 < iBeta && iBeta < iAlpha)) {
+	// Arc approximates a full ellipse
+	return iM * Vector(iAlpha + IpePi);
     }
 
+    double delta = Angle(iBeta - iAlpha).normalize(0.0);
+
     if (sq(delta) < 1e-20) {
-	// Zero-length arc, return the starting point
+	// Arc approximately zero-length, return the starting point
 	return iM * Vector(iAlpha);
     }
 
-    Angle midAngle(iAlpha + delta / 2);
-    return iM * Vector(midAngle);
+    return iM * Vector(iAlpha + delta / 2);
 }
 
 //! Find (approximately) nearest point on Bezier spline.

--- a/src/ipelib/ipeshape.cpp
+++ b/src/ipelib/ipeshape.cpp
@@ -230,10 +230,12 @@ void CurveSegment::snapVtx(const Vector & mouse, const Matrix & m, Vector & pos,
 	break;
     case EArc:
 	// snap to center and endpoints
-	if (ctl)
+	if (ctl) {
 	    // center
 	    snapVertex(mouse, (m * matrix()).translation(), pos, bound);
-	else
+	    // midpoint
+	    snapVertex(mouse, m * arc().midpoint(), pos, bound);
+	} else
 	    snapVertex(mouse, m * cp(1), pos, bound);
 	break;
     case ESpline:


### PR DESCRIPTION
Currently, there is no "midpoint snapping" for circular arcs like there is for line segments.
It would make sense for completeness' sake to also have it for circular arcs, and it's also practical.
Bisecting angles is common, and the usual workaround I have seen colleagues use involves a cumbersome construction where a line is drawn through the two intersection points of two circles... 