### PR TITLE
Enable picking and applying of markshape property of reference objects

### DIFF
--- a/src/ipe/lua/properties.lua
+++ b/src/ipe/lua/properties.lua
@@ -591,6 +591,7 @@ function MODEL:pick_properties_reference(obj)
   a.fill = obj:get("fill")
   a.pen = obj:get("pen")
   a.symbolsize = obj:get("symbolsize")
+  a.markshape = obj:get("markshape")
 end
 
 ----------------------------------------------------------------------
@@ -672,6 +673,7 @@ function apply_properties_reference(obj, a)
   obj:set("fill", a.fill)
   obj:set("pen", a.pen)
   obj:set("symbolsize", a.symbolsize)
+  obj:set("markshape", a.markshape)
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Currently, the "markshape" attribute of references cannot be picked nor applied.
It seems this is a bug, and the proposed new behaviour is useful when working with multiple types of marks.