### PR TITLE
Proposal: In SelectTool, if cursor is close enough, prefer reference objects

### DIFF
--- a/src/ipecanvas/ipetool.cpp
+++ b/src/ipecanvas/ipetool.cpp
@@ -116,6 +116,11 @@ SelectTool::SelectTool(CanvasBase * canvas, Page * page, int view, double select
 	    if ((d = iPage->distance(i, v, bound)) < bound) {
 		SObj obj;
 		obj.index = i;
+		if (iPage->object(i)->type() == Object::Type::EReference
+		    && d < bound / 2) {
+		    // If cursor is close enough, prefer reference objects
+		    d -= bound;
+		}
 		obj.distance = d;
 		iObjs.push_back(obj);
 	    }


### PR DESCRIPTION
In my experience, it occurs often (especially when drawing graphs) that numerous line segments end directly on the center of a mark.
Now, when a user wishes to select the mark by precisely clicking on it, an effectively random line is selected, and one has to cycle through O(# of adjacent paths) options.

This PR proposes to improve this by prioritizing all reference objects when the distance to the reference is "very close" (1/2 of the selection radius).