### PR TITLE
do not pick the pen property of reference objects

### DIFF
--- a/src/ipe/lua/properties.lua
+++ b/src/ipe/lua/properties.lua
@@ -589,7 +589,6 @@ function MODEL:pick_properties_reference(obj)
   local a = self.attributes
   a.stroke = obj:get("stroke")
   a.fill = obj:get("fill")
-  a.pen = obj:get("pen")
   a.symbolsize = obj:get("symbolsize")
   a.markshape = obj:get("markshape")
 end


### PR DESCRIPTION
Picking the "pen" attribute of a mark led to setting the preset for the "pen" to undefined (or at least polygons drawn after picking had "pen" set to undefined).

I don't think that reference objects can have the "pen" attribute set.

If I am wrong about this, then my fix is probably a bad idea.