### PR TITLE
fixed math expressions in documentation and moved paranthesis

### DIFF
--- a/manual/40_snapping.rst
+++ b/manual/40_snapping.rst
@@ -172,8 +172,8 @@ set.
 
 You can hide the current axis system by pressing :kbd:`Ctrl+F1`. This
 also turns off angular snapping, but preserves origin and orientation of
-the axes.  To reset the orientation (such that the $x$-axis is
-horizontal, use :kbd:`Ctrl+F2`).
+the axes.  To reset the orientation (such that the :math:`x`-axis is
+horizontal), use :kbd:`Ctrl+F2`.
 
 You can set origin and base direction at the same time by pressing
 :kbd:`F3` when the mouse is very near (or snapped to) an edge of a

--- a/manual/60_stylesheets.rst
+++ b/manual/60_stylesheets.rst
@@ -199,7 +199,7 @@ it should contain either a path object or a group of path objects.
 Ipe resizes these path objects so that they fit nicely around the
 bounding box of the group object being decorated.  For this to work
 correctly, the decoration object must be drawn such that it decorates
-the rectangle with corners at $(100, 100)$ and $(300, 200)$. 
+the rectangle with corners at :math:`(100, 100)` and :math:`(300, 200)`. 
 
 To make a decoration symbol, follow these steps:
 

--- a/manual/90_file_format.rst
+++ b/manual/90_file_format.rst
@@ -392,7 +392,7 @@ Each operator follows its arguments.  The operators are
 
 ``c`` (cubic B-spline) (:math:`n` point arguments): 
   add a uniform cubic B-spline with :math:`n+1` control points (the current
-  position plus the $n$ arguments).  If :math:`n = 3`, this is equivalent to
+  position plus the :math:`n` arguments).  If :math:`n = 3`, this is equivalent to
   a single cubic |bezier| spline, if :math:`n = 2` it is equivalent to a
   single quadratic |bezier| spline.
 


### PR DESCRIPTION
Math in documentation wasn't rendering correctly and a parenthesis in manual/40_snapping.rst was placed incorrectly.